### PR TITLE
Always use the last "" match for the user agent.

### DIFF
--- a/mycode.py
+++ b/mycode.py
@@ -26,6 +26,6 @@ with open('outputs/all.csv', "w") as output_file:
                         version = version.replace(".", "", 1)
                         platform = match.group(2)
                         date = re.search(r'\[(.*?)\]', line).group(1)
-                        user_agent = re.findall(r'"(.+?)"', line)[2]
+                        user_agent = re.findall(r'"(.+?)"', line)[-1]
                         if 'bot' not in user_agent.lower() and 'spider' not in user_agent.lower() and 'crawl' not in user_agent.lower():
                             writer.writerow([date, version, platform])


### PR DESCRIPTION
This avoids problems where less than 3 quoted blocks exist in a log line.